### PR TITLE
feat: 限制气体开采产能

### DIFF
--- a/src/app/components/resource-input/resource-input.component.spec.ts
+++ b/src/app/components/resource-input/resource-input.component.spec.ts
@@ -1,23 +1,106 @@
+import { computed } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ObjectiveType } from '~/models/enum/objective-type';
+import { fromNumber,rational } from '~/models/rational';
+import { SettingsService } from '~/store/settings.service';
+import { TestModule } from '~/tests';
 
 import { ResourceInputComponent } from './resource-input.component';
 
 describe('ResourceInputComponent', () => {
   let component: ResourceInputComponent;
   let fixture: ComponentFixture<ResourceInputComponent>;
+  let settingsSvc: SettingsService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ResourceInputComponent]
-    })
-    .compileComponents();
+      imports: [TestModule, ResourceInputComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ResourceInputComponent);
     component = fixture.componentInstance;
+    settingsSvc = TestBed.inject(SettingsService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should always expose gas resources for direct-mining limits', () => {
+    expect(component.limitItems()).toEqual([
+      { id: 'originium_ore', recipe: 'originium_ore' },
+      { id: 'quartz_sand', recipe: 'quartz_sand' },
+      { id: 'iron_ore', recipe: 'iron_ore' },
+      { id: 'copper_ore', recipe: 'copper_ore-liquid_water' },
+      { id: 'gas_xiranite', recipe: 'gas_xiranite' },
+      { id: 'gas_inert', recipe: 'gas_inert' },
+    ]);
+  });
+
+  it('should convert gas resource limits to RecipeLimit instead of ItemLimit', () => {
+    const origData = component.data();
+    component.data = computed(() => ({
+      ...origData,
+      adjustedRecipe: {
+        ...origData.adjustedRecipe,
+        gas_xiranite: { time: rational(3n), out: { gas_xiranite: rational(1n) } } as any,
+        gas_inert: { time: rational(3n), out: { gas_inert: rational(1n) } } as any,
+      },
+    }));
+    component.ready.set(true);
+    component.enableLimitItems.set(true);
+    component.limitItemsNum.set({
+      originium_ore: fromNumber(560),
+      quartz_sand: fromNumber(240),
+      iron_ore: fromNumber(1080),
+      copper_ore: rational.zero,
+      gas_xiranite: rational(5n),
+      gas_inert: rational.zero,
+    });
+    fixture.detectChanges();
+
+    const objectives = Object.values(component.objectivesSvc.state());
+
+    // Gas resources should produce RecipeLimit, not ItemLimit
+    const gasRecipeLimit = objectives.find(
+      (o) =>
+        o.type === ObjectiveType.RecipeLimit && o.targetId === 'gas_xiranite',
+    );
+    expect(gasRecipeLimit?.value).toEqual(rational(1n, 4n));
+    expect(
+      objectives.some(
+        (o) =>
+          o.type === ObjectiveType.ItemLimit && o.targetId === 'gas_xiranite',
+      ),
+    ).toBeFalse();
+
+    // Solid resources still get ItemLimit + ItemLimitOutput
+    const displayRate = settingsSvc.displayRateInfo().value;
+    const rateFactor = displayRate.mul(rational(1n, 60n));
+
+    const ironItemLimit = objectives.find(
+      (o) => o.type === ObjectiveType.ItemLimit && o.targetId === 'iron_ore',
+    );
+    expect(ironItemLimit).toBeTruthy();
+    expect(ironItemLimit?.value).toEqual(fromNumber(1080).mul(rateFactor));
+
+    const ironOutputLimit = objectives.find(
+      (o) =>
+        o.type === ObjectiveType.ItemLimitOutput && o.targetId === 'iron_ore',
+    );
+    expect(ironOutputLimit).toBeTruthy();
+    expect(ironOutputLimit?.value).toEqual(
+      fromNumber(1080).div(fromNumber(20)),
+    );
+  });
+
+  it('should prefill direct gas mining limits for Jinlong 1.4', () => {
+    component.applyOneKey('jinlong1.4');
+
+    expect(component.enableLimitItems()).toBeTrue();
+    expect(component.limitItemsNum()['gas_xiranite']).toEqual(fromNumber(100));
+    expect(component.limitItemsNum()['gas_inert']).toEqual(fromNumber(460));
   });
 });

--- a/src/app/components/resource-input/resource-input.component.ts
+++ b/src/app/components/resource-input/resource-input.component.ts
@@ -83,6 +83,8 @@ export class ResourceInputComponent {
     { id: 'quartz_sand', recipe: 'quartz_sand' },
     { id: 'iron_ore', recipe: 'iron_ore' },
     { id: 'copper_ore', recipe: 'copper_ore-liquid_water' },
+    { id: 'gas_xiranite', recipe: 'gas_xiranite' },
+    { id: 'gas_inert', recipe: 'gas_inert' },
   ]);
   enableLimitItems = signal(false);
   limitItemsNum = signal<Record<string, Rational>>({});
@@ -141,7 +143,8 @@ export class ResourceInputComponent {
         { id: 'quartz_sand', num: rational.zero },
         { id: 'iron_ore', num: fromNumber(120) },
         { id: 'copper_ore', num: fromNumber(420) },
-        // TODO 需要气矿的数据
+        { id: 'gas_xiranite', num: fromNumber(100) },
+        { id: 'gas_inert', num: fromNumber(460) },
       ],
       limitMachines: [{ id: 'xiranite_oven_1', num: fromNumber(12) }],
       transferSource: 'tundra',
@@ -291,7 +294,21 @@ export class ResourceInputComponent {
           removeLimits((it) => needRemove.has(it.targetId));
           untracked(() => {
             const needAdd = limitItems.flatMap<ObjectiveBase>((it) => {
-              const ret = [
+              const recipe = this.data().adjustedRecipe[it.recipe];
+              const output = recipe?.out[it.id];
+              const isGasMining = it.id === 'gas_xiranite' || it.id === 'gas_inert';
+              if (isGasMining && recipe && output) {
+                const recipeTime = recipe.time ?? rational.one;
+                const value: Rational = it.num.div(displayRate).mul(recipeTime).div(output);
+                const gasLimit: ObjectiveBase = {
+                  targetId: it.recipe,
+                  unit: ObjectiveUnit.Machines,
+                  type: ObjectiveType.RecipeLimit as ObjectiveType,
+                  value,
+                };
+                return [gasLimit];
+              }
+              const ret: ObjectiveBase[] = [
                 {
                   targetId: it.id,
                   unit: ObjectiveUnit.Items,
@@ -315,7 +332,9 @@ export class ResourceInputComponent {
           removeLimits(
             (it) =>
               it.type === ObjectiveType.ItemLimit ||
-              it.type === ObjectiveType.ItemLimitOutput,
+              it.type === ObjectiveType.ItemLimitOutput ||
+              (it.type === ObjectiveType.RecipeLimit &&
+               (it.targetId === 'gas_xiranite' || it.targetId === 'gas_inert')),
           );
         }
       }

--- a/src/app/models/constants.ts
+++ b/src/app/models/constants.ts
@@ -4,10 +4,7 @@ import { Entities } from './utils';
 export const APP = 'EndfieldLab';
 
 export const ARKNIGHTS_ENDFIELD_ID = 'aef';
-export const DEFAULT_MOD = environment.production
-  ? // istanbul ignore next: Don't test default mod set to endfield for production
-    ARKNIGHTS_ENDFIELD_ID
-  : 'spa';
+export const DEFAULT_MOD = ARKNIGHTS_ENDFIELD_ID;
 
 export const MIN_LINK_VALUE = 1e-10;
 export const MIN_ZIP = 200;

--- a/src/app/models/enum/objective-type.ts
+++ b/src/app/models/enum/objective-type.ts
@@ -10,6 +10,7 @@ export enum ObjectiveType {
   ItemLimitOutput = 12,
   MachineLimit = 13,
   DomainTransfer = 14,
+  RecipeLimit = 15,
 }
 
 export const objectiveTypeOptions: SelectItem<ObjectiveType>[] = [

--- a/src/app/services/simplex.service.spec.ts
+++ b/src/app/services/simplex.service.spec.ts
@@ -4,6 +4,7 @@ import { MaximizeType } from '~/models/enum/maximize-type';
 import { ObjectiveType } from '~/models/enum/objective-type';
 import { ObjectiveUnit } from '~/models/enum/objective-unit';
 import { SimplexResultType } from '~/models/enum/simplex-result-type';
+import { AdjustedRecipe } from '~/models/data/recipe';
 import { rational } from '~/models/rational';
 import { Entities } from '~/models/utils';
 import { ItemId, Mocks, RecipeId, TestModule } from '~/tests';
@@ -327,6 +328,28 @@ describe('SimplexService', () => {
       const result = service.getSolution(state);
       expect(result.resultType).toEqual(SimplexResultType.Failed);
     });
+
+    it('should add recipe limits to matrix state', () => {
+      const objectives = [
+        {
+          id: 'recipe-limit',
+          targetId: RecipeId.CopperPlate,
+          type: ObjectiveType.RecipeLimit,
+          unit: ObjectiveUnit.Machines,
+          value: rational(5n),
+        },
+      ];
+
+      const result = service.getState(
+        objectives,
+        Mocks.settingsStateInitial,
+        Mocks.adjustedDataset,
+      );
+
+      expect(result.recipeLimits).toEqual({
+        [RecipeId.CopperPlate]: rational(5n),
+      });
+    });
   });
 
   describe('itemCost', () => {
@@ -460,6 +483,72 @@ describe('SimplexService', () => {
       const state = getState();
       const result = service.glpk(state);
       expect(result.returnCode).toEqual('failure');
+    });
+
+    it('should apply recipe limits only to the target recipe', () => {
+      const state = service.getState([], Mocks.settingsStateInitial, Mocks.adjustedDataset);
+
+      // Two recipes producing the same item (CopperPlate)
+      // natural-gas: cheap (cost 0), with limit 1
+      // synthetic-gas: more expensive (cost 10), no limit
+      // Demand = 2 → natural-gas capped at 1, synthetic-gas fills remainder at 1
+      const naturalGas: AdjustedRecipe = {
+        id: 'natural-gas',
+        name: 'Natural Gas',
+        category: 'mining',
+        row: 0,
+        time: rational.one,
+        producers: [],
+        in: {},
+        out: { [ItemId.CopperPlate]: rational.one },
+        effects: {
+          consumption: rational.one,
+          pollution: rational.one,
+          productivity: rational.one,
+          quality: rational.zero,
+          speed: rational.one,
+        },
+        produces: new Set([ItemId.CopperPlate]),
+        output: { [ItemId.CopperPlate]: rational.one },
+        cost: rational.zero,
+        flags: new Set(),
+      };
+
+      const syntheticGas: AdjustedRecipe = {
+        ...naturalGas,
+        id: 'synthetic-gas',
+        name: 'Synthetic Gas',
+        cost: rational(10n),
+      };
+
+      state.recipes = {
+        'natural-gas': naturalGas,
+        'synthetic-gas': syntheticGas,
+      };
+
+      state.data.itemAvailableIoRecipeIds[ItemId.CopperPlate] = [
+        'natural-gas',
+        'synthetic-gas',
+      ];
+
+      state.itemValues = {
+        [ItemId.CopperPlate]: { out: rational(2n) },
+      };
+
+      state.recipeLimits = {
+        'natural-gas': rational(1n),
+      };
+
+      state.itemIds = [ItemId.CopperPlate];
+      state.recipeObjectives = [];
+      state.unproduceableIds = new Set();
+      state.excludedIds = new Set();
+
+      const result = service.glpk(state);
+      expect(result.returnCode).toEqual('ok');
+      expect(result.status).toEqual('optimal');
+      expect(result.recipes['natural-gas']).toEqual(rational.one);
+      expect(result.recipes['synthetic-gas']).toEqual(rational.one);
     });
   });
 

--- a/src/app/services/simplex.service.ts
+++ b/src/app/services/simplex.service.ts
@@ -274,6 +274,13 @@ export class SimplexService {
             }
             break;
           }
+          case ObjectiveType.RecipeLimit: {
+            const current = state.recipeLimits[obj.targetId];
+            if (current == null || current.gt(obj.value)) {
+              state.recipeLimits[obj.targetId] = obj.value;
+            }
+            break;
+          }
         }
       } else {
         switch (obj.type) {


### PR DESCRIPTION
- 新增 RecipeLimit 目标类型，限制息壤气和惰气采集配方的每秒生产周期；合成配方不受影响
- 将资源配置中的气体每分钟速率按配方周期产出与耗时换算为 RecipeLimit 上限，固体矿继续使用 ItemLimit
- 为武陵 1.4 预设息壤气 100/min、惰气 460/min 的产能上限
- 修复非生产环境的 DEFAULT_MOD 指向不存在的 spa 数据集而导致启动 404 的问题